### PR TITLE
[WIP] Extract vec without specialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* `FromPyObject` is now automatically implemented for `T: Clone` pyclasses. [#730](https://github.com/PyO3/pyo3/pull/730)
 * Implemented `IntoIterator` for `PySet` and `PyFrozenSet`. [#716](https://github.com/PyO3/pyo3/pull/716)
 * `PyClass`, `PyClassShell`, `PyObjectLayout`, `PyClassInitializer` [#683](https://github.com/PyO3/pyo3/pull/683)
 

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -395,6 +395,18 @@ fn impl_class(
             #weakref
         }
 
+        impl pyo3::FromPyObjectImpl for #cls {
+            type Impl = pyo3::extract_impl::Cloned;
+        }
+
+        impl pyo3::FromPyObjectImpl for &'_ #cls {
+            type Impl = pyo3::extract_impl::Reference;
+        }
+
+        impl pyo3::FromPyObjectImpl for &'_ mut #cls {
+            type Impl = pyo3::extract_impl::MutReference;
+        }
+
         #into_pyobject
 
         #inventory_impl

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! `PyBuffer` implementation
+use crate::conversion;
 use crate::err::{self, PyResult};
 use crate::exceptions;
 use crate::ffi;
@@ -634,6 +635,10 @@ macro_rules! impl_element(
                 }
                 ElementType::from_format(format) == ElementType::$f { bytes: mem::size_of::<$t>() }
             }
+        }
+
+        impl conversion::FromPyObjectImpl for $t {
+            type Impl = conversion::extract_impl::BufferElement;
         }
     }
 );

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -251,6 +251,7 @@ pub mod extract_impl {
         fn extract(source: &'a PyAny) -> PyResult<Target>;
     }
 
+    pub struct BufferElement;
     pub struct Cloned;
     pub struct Reference;
     pub struct MutReference;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,8 @@
 
 pub use crate::class::*;
 pub use crate::conversion::{
-    AsPyPointer, FromPy, FromPyObject, FromPyPointer, IntoPy, IntoPyPointer, PyTryFrom, PyTryInto,
-    ToBorrowedObject, ToPyObject,
+    extract_impl, AsPyPointer, FromPy, FromPyObject, FromPyObjectImpl, FromPyPointer, IntoPy,
+    IntoPyPointer, PyTryFrom, PyTryInto, ToBorrowedObject, ToPyObject,
 };
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyErrValue, PyResult};
 pub use crate::gil::{init_once, GILGuard, GILPool};

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -2,6 +2,7 @@
 //
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
+use crate::conversion::extract_impl;
 use crate::err::PyErr;
 use crate::ffi;
 use crate::instance::PyNativeType;
@@ -9,7 +10,6 @@ use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::objectprotocol::ObjectProtocol;
 use crate::types::PyAny;
-use crate::FromPyObject;
 use crate::PyResult;
 use crate::Python;
 use crate::ToPyObject;
@@ -56,10 +56,10 @@ impl FromPy<f64> for PyObject {
     }
 }
 
-impl<'source> FromPyObject<'source> for f64 {
+impl<'source> extract_impl::ExtractImpl<'source, f64> for extract_impl::BufferElement {
     // PyFloat_AsDouble returns -1.0 upon failure
     #![cfg_attr(feature = "cargo-clippy", allow(clippy::float_cmp))]
-    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+    fn extract(obj: &'source PyAny) -> PyResult<f64> {
         let v = unsafe { ffi::PyFloat_AsDouble(obj.as_ptr()) };
 
         if v == -1.0 && PyErr::occurred(obj.py()) {
@@ -82,8 +82,8 @@ impl FromPy<f32> for PyObject {
     }
 }
 
-impl<'source> FromPyObject<'source> for f32 {
-    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+impl<'source> extract_impl::ExtractImpl<'source, f32> for extract_impl::BufferElement {
+    fn extract(obj: &'source PyAny) -> PyResult<f32> {
         Ok(obj.extract::<f64>()? as f32)
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -164,6 +164,10 @@ macro_rules! pyobject_native_type_convert(
             }
         }
 
+        impl<$($type_param,)*> $crate::conversion::FromPyObjectImpl for &'_ $name {
+            type Impl = $crate::extract_impl::Reference;
+        }
+
         impl<$($type_param,)*> ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter)
                    -> Result<(), ::std::fmt::Error>

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -2,6 +2,7 @@
 //
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
+use crate::conversion::extract_impl::{ExtractImpl, BufferElement};
 use crate::err::{PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi;
@@ -44,8 +45,8 @@ macro_rules! int_fits_larger_int {
             }
         }
 
-        impl<'source> FromPyObject<'source> for $rust_type {
-            fn extract(obj: &'source PyAny) -> PyResult<Self> {
+        impl<'source> ExtractImpl<'source, $rust_type> for BufferElement {
+            fn extract(obj: &'source PyAny) -> PyResult<$rust_type> {
                 let val = $crate::objectprotocol::ObjectProtocol::extract::<$larger_type>(obj)?;
                 match cast::<$larger_type, $rust_type>(val) {
                     Some(v) => Ok(v),
@@ -141,8 +142,8 @@ macro_rules! int_fits_c_long {
             }
         }
 
-        impl<'source> FromPyObject<'source> for $rust_type {
-            fn extract(obj: &'source PyAny) -> PyResult<Self> {
+        impl<'source> ExtractImpl<'source, $rust_type> for BufferElement {
+            fn extract(obj: &'source PyAny) -> PyResult<$rust_type> {
                 let ptr = obj.as_ptr();
                 let val = unsafe {
                     let num = ffi::PyNumber_Index(ptr);
@@ -177,7 +178,7 @@ macro_rules! int_convert_u64_or_i64 {
                 unsafe { PyObject::from_owned_ptr_or_panic(py, $pylong_from_ll_or_ull(self)) }
             }
         }
-        impl<'source> FromPyObject<'source> for $rust_type {
+        impl<'source> ExtractImpl<'source, $rust_type> for BufferElement {
             fn extract(ob: &'source PyAny) -> PyResult<$rust_type> {
                 let ptr = ob.as_ptr();
                 unsafe {

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
 use crate::buffer;
+use crate::conversion;
 use crate::err::{self, PyDowncastError, PyErr, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::instance::PyNativeType;
@@ -241,20 +242,14 @@ impl PySequence {
     }
 }
 
-impl<'a, T> FromPyObject<'a> for Vec<T>
-where
-    T: FromPyObject<'a>,
-{
-    default fn extract(obj: &'a PyAny) -> PyResult<Self> {
-        extract_sequence(obj)
-    }
+pub trait ExtractVecImpl<'a, Target> {
+    fn extract_vec(obj: &'a PyAny) -> PyResult<Vec<Target>>;
 }
 
-impl<'source, T> FromPyObject<'source> for Vec<T>
-where
-    for<'a> T: FromPyObject<'a> + buffer::Element + Copy,
+impl<'a, T> ExtractVecImpl<'a, T> for conversion::extract_impl::BufferElement
+where T: buffer::Element + Copy + FromPyObject<'a>
 {
-    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+    fn extract_vec(obj: &'a PyAny) -> PyResult<Vec<T>> {
         // first try buffer protocol
         if let Ok(buf) = buffer::PyBuffer::get(obj.py(), obj) {
             if buf.dimensions() == 1 {
@@ -269,6 +264,53 @@ where
         extract_sequence(obj)
     }
 }
+
+macro_rules! default_extract_vec_impl{
+    ($ty:ty) => {
+        impl<'a, T> ExtractVecImpl<'a, T> for $ty
+        where T: FromPyObject<'a>
+        {
+            fn extract_vec(obj: &'a PyAny) -> PyResult<Vec<T>> {
+                // fall back to sequence protocol
+                extract_sequence(obj)
+            }
+        }
+    };
+}
+
+default_extract_vec_impl!(conversion::extract_impl::Cloned);
+default_extract_vec_impl!(conversion::extract_impl::Reference);
+default_extract_vec_impl!(conversion::extract_impl::MutReference);
+
+impl<'a, T> FromPyObject<'a> for Vec<T>
+where
+    T: conversion::FromPyObjectImpl,
+    <T as conversion::FromPyObjectImpl>::Impl: ExtractVecImpl<'a, T>
+{
+    fn extract(obj: &'a PyAny) -> PyResult<Self> {
+        <T as conversion::FromPyObjectImpl>::Impl::extract_vec(obj)
+    }
+}
+
+// impl<'source, T> FromPyObject<'source> for Vec<T>
+// where
+//     for<'a> T: FromPyObject<'a> + buffer::Element + Copy,
+// {
+//     fn extract(obj: &'source PyAny) -> PyResult<Self> {
+//         // first try buffer protocol
+//         if let Ok(buf) = buffer::PyBuffer::get(obj.py(), obj) {
+//             if buf.dimensions() == 1 {
+//                 if let Ok(v) = buf.to_vec::<T>(obj.py()) {
+//                     buf.release(obj.py());
+//                     return Ok(v);
+//                 }
+//             }
+//             buf.release(obj.py());
+//         }
+//         // fall back to sequence protocol
+//         extract_sequence(obj)
+//     }
+// }
 
 fn extract_sequence<'s, T>(obj: &'s PyAny) -> PyResult<Vec<T>>
 where

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -1,0 +1,25 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+#[derive(Clone, Debug, PartialEq)]
+struct Cloneable {
+    x: i32,
+}
+
+#[test]
+fn test_cloneable_pyclass() {
+    let c = Cloneable { x: 10 };
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let py_c = Py::new(py, c.clone()).unwrap().to_object(py);
+
+    let c2: Cloneable = py_c.extract(py).unwrap();
+    let rc: &Cloneable = py_c.extract(py).unwrap();
+    let mrc: &mut Cloneable = py_c.extract(py).unwrap();
+
+    assert_eq!(c, c2);
+    assert_eq!(&c, rc);
+    assert_eq!(&c, mrc);
+}

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,7 +1,8 @@
 #[test]
 fn test_compile_errors() {
     let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/invalid_pymethod_names.rs");
+    t.compile_fail("tests/ui/missing_clone.rs");
     t.compile_fail("tests/ui/reject_generics.rs");
     t.compile_fail("tests/ui/too_many_args_to_getter.rs");
-    t.compile_fail("tests/ui/invalid_pymethod_names.rs");
 }

--- a/tests/test_extract.rs
+++ b/tests/test_extract.rs
@@ -23,3 +23,14 @@ fn test_cloneable_pyclass() {
     assert_eq!(&c, rc);
     assert_eq!(&c, mrc);
 }
+
+#[test]
+fn test_extract_buffer() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let bytes = py.eval("b'abcde'", None, None).unwrap();
+
+    let chars: Vec<u8> = bytes.to_object(py).extract(py).unwrap();
+
+    assert_eq!(&chars, &['a' as u8, 'b' as u8, 'c' as u8, 'd' as u8, 'e' as u8])
+}

--- a/tests/ui/missing_clone.rs
+++ b/tests/ui/missing_clone.rs
@@ -1,0 +1,16 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+struct TestClass {
+    num: u32,
+}
+
+fn main() {
+    let t = TestClass { num: 10 };
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let pyvalue = Py::new(py, t).unwrap().to_object(py);
+    let t: TestClass = pyvalue.extract(py).unwrap();
+}

--- a/tests/ui/missing_clone.stderr
+++ b/tests/ui/missing_clone.stderr
@@ -1,0 +1,8 @@
+error[E0277]: the trait bound `TestClass: std::clone::Clone` is not satisfied
+  --> $DIR/missing_clone.rs:15:32
+   |
+15 |     let t: TestClass = pyvalue.extract(py).unwrap();
+   |                                ^^^^^^^ the trait `std::clone::Clone` is not implemented for `TestClass`
+   |
+   = note: required because of the requirements on the impl of `pyo3::conversion::extract_impl::ExtractImpl<'_, TestClass>` for `pyo3::conversion::extract_impl::Cloned`
+   = note: required because of the requirements on the impl of `pyo3::conversion::FromPyObject<'_>` for `TestClass`


### PR DESCRIPTION
Attempt to implement `FromPyObject` for `Vec<T>` with a buffer optimisation, *without* specialisation.

Can't merge because:

In this new design, `FromPyObject` for `Vec<String>` is not currently implemented, but `FromPyObject` for `String` is. In general this is a problem for all types which implement `FromPyObject` instead of `FromPyObjectImpl`.

Probably the solution is to make it ergonomic to implement `FromPyObjectImpl` directly for all types.